### PR TITLE
fix manga_root parameter

### DIFF
--- a/bin/manga-downloadr
+++ b/bin/manga-downloadr
@@ -36,7 +36,7 @@ rescue OptionParser::ParseError
 end
 
 require 'manga-downloadr'
-generator = MangaDownloadr::Workflow.create(options[:url], options[:name], manga_root: options[:directory])
+generator = MangaDownloadr::Workflow.create(options[:url], options[:name], options[:directory])
 unless generator.state?(:chapter_urls)
   puts "Massive parallel scanning of all chapters "
   generator.fetch_chapter_urls!

--- a/lib/manga-downloadr.rb
+++ b/lib/manga-downloadr.rb
@@ -171,10 +171,10 @@ module MangaDownloadr
         File.open("/tmp/#{obj.manga_name}.yaml", 'w') {|f| f.write(YAML::dump(obj)) }
       end
 
-      def create(root_url, manga_name, options = {})
+      def create(root_url, manga_name, manga_root, options = {})
         dump_file_name = "/tmp/#{manga_name}.yaml"
         return YAML::load(File.read(dump_file_name)) if File.exists?(dump_file_name)
-        MangaDownloadr::Workflow.new(root_url, manga_name, options)
+        MangaDownloadr::Workflow.new(root_url, manga_name, manga_root, options)
       end
     end
   end


### PR DESCRIPTION
Manga root parameter was raising an error 
The `MangaDownloadr::Workflow#initialize` was expecting a string and the `MangaDownloadr::Workflow.create` was giving a hash
